### PR TITLE
ci: add check for missing generation of migrations

### DIFF
--- a/.github/workflows/elixir-static-code-analysis.yml
+++ b/.github/workflows/elixir-static-code-analysis.yml
@@ -43,6 +43,8 @@ jobs:
       run: mix deps.unlock --check-unused
     - name: Check code formatting
       run: mix format --check-formatted
+    - name: Check for missing generation of migrations
+      run: mix ash.codegen --check
     - name: credo
       run: mix credo
     - name: sobelow


### PR DESCRIPTION
When editing Ash resource it not always the dev remembers to generate the appropriate migrations. This checks if this has been done.