### PR TITLE
fix: load the user on comments sent using Phoenix broadcast

### DIFF
--- a/lib/case_manager_web/live/case_live/show.ex
+++ b/lib/case_manager_web/live/case_live/show.ex
@@ -23,7 +23,7 @@ defmodule CaseManagerWeb.CaseLive.Show do
         %Phoenix.Socket.Broadcast{event: "create", payload: %Ash.Notifier.Notification{data: comment}},
         socket
       ) do
-    comment = Map.put(comment, :header, nil)
+    comment = comment |> Ash.load!(:user) |> Map.put(:header, nil)
     {:noreply, stream_insert(socket, :comments, comment, at: 0)}
   end
 


### PR DESCRIPTION
Fixes: #229

### Changes
 - Loads the name on the user when they are sending a comment.