### PR TITLE
chore: improve sanitization of the markdown render

### DIFF
--- a/lib/case_manager_web/helpers.ex
+++ b/lib/case_manager_web/helpers.ex
@@ -12,6 +12,7 @@ defmodule CaseManagerWeb.Helpers do
     text
     |> HtmlSanitizeEx.strip_tags()
     |> Earmark.as_html!()
+    |> HtmlSanitizeEx.markdown_html()
     |> Phoenix.HTML.raw()
   end
 


### PR DESCRIPTION
The input wasn't sanitized after rendering allowing you to leverage markdown syntax to render links with javascript in them.
